### PR TITLE
Refund conditions

### DIFF
--- a/interbtc-spec/docs/source/spec/redeem.rst
+++ b/interbtc-spec/docs/source/spec/redeem.rst
@@ -254,7 +254,7 @@ Specification
 * The BTC Parachain status in the :ref:`security` component MUST NOT be set to ``SHUTDOWN:2``.
 * A *pending* ``RedeemRequest`` MUST exist with an id equal to ``redeemId``.
 * The request MUST NOT have expired.
-* * The ``rawTx`` MUST decode to a valid transaction that transfers at least the amount specified in the ``RedeemRequest`` struct. It MUST be a transaction to the correct address, and provide the expected OP_RETURN, based on the ``RedeemRequest``.
+* The ``rawTx`` MUST decode to a valid transaction that transfers the amount specified in the ``RedeemRequest`` struct. It MUST be a transaction to the correct address, and provide the expected OP_RETURN, based on the ``RedeemRequest``.
 * The ``merkleProof`` MUST contain a valid proof of of ``rawTX``.
 * The bitcoin payment MUST have been submitted to the relay chain, and MUST have sufficient confirmations.
 

--- a/interbtc-spec/docs/source/spec/refund.rst
+++ b/interbtc-spec/docs/source/spec/refund.rst
@@ -70,11 +70,13 @@ Specification
 * The ``merkleProof`` MUST contain a valid proof of of ``rawTX``.
 * The bitcoin payment MUST have been submitted to the relay chain, and MUST have sufficient confirmations.
 * The ``vault.status`` MUST be ``active``.
-* The ``vault.isBanned()`` MUST return ``false``.
+* ``vault.isBanned()`` MUST return ``false``.
 * The refunding vault MUST have enough collateral to mint an amount equal to the refund fee.
 
 *Postconditions*
 
 * The ``vault.issuedTokens`` MUST increase by ``fee``.
 * The ``TotalSupply`` in the :ref:`treasury-module` MUST increase by ``fee``.
+* The vault's free balance in the :ref:`treasury-module` MUST increase by ``fee``.
 * The vault's ``SLA`` MUST increase by the :ref:`sla` score of ``Refund``.
+* ``refundRequest.completed`` MUST be ``true``.

--- a/interbtc-spec/docs/source/spec/refund.rst
+++ b/interbtc-spec/docs/source/spec/refund.rst
@@ -19,7 +19,7 @@ If a user falsely sends additional BTC (i.e., :math:`|\text{BTC}| > |\text{inter
     c. Emit an event that the issue amount was increased.
 2. **Case 2: The originally selected vault does NOT have sufficient collateral locked to cover the additional BTC amount sent by the user**:
     a. Automatically create a return request from the issue module that includes a return fee (deducted from the originial BTC payment) paid to the vault returning the BTC.
-    b. The vault fulfills the return request via a transaction inclusion proof (similar to execute issue). However, this does not create a new interbtc.
+    b. The vault fulfills the return request via a transaction inclusion proof (similar to execute issue). However, this does not create new interbtc.
 
 .. note:: Only case 2 is handled in this module. Case 1 is handled directly by the issue module.
 
@@ -30,3 +30,51 @@ Security
 --------
 
 - Unique identification of Bitcoin payments: :ref:`op-return`
+
+Functions
+~~~~~~~~~
+
+.. _executeRefund:
+
+executeRefund
+--------------
+
+This function finalizes a refund, also referred to as a user failsafe. 
+It is typically called by the vault client that performed the refund.
+
+Specification
+.............
+
+*Function Signature*
+
+``execute_refund(caller, refundId, merkleProof, rawTx)``
+
+*Parameters*
+
+* ``caller``: address of the user finalizing the refund. Typically the vault client that performed the refund.
+* ``refundId``: the unique hash created during the internal ``requestRefund`` function.
+* ``merkleProof``: merkle tree path (concatenated LE SHA256 hashes).
+* ``rawTx``: raw Bitcoin transaction of the refund payment, including the transaction inputs and outputs.
+
+*Events*
+
+* ``ExecuteRefund(refundId, issuer, vault, amount, fee)``
+
+*Preconditions*
+
+* The function call MUST be signed be *someone*, i.e. not necessarily the vault client that performed the refund.
+* The BTC Parachain status in the :ref:`security` component MUST NOT be set to ``SHUTDOWN:2``.
+* A *pending* ``RefundRequest`` MUST exist with an id equal to ``refundId``.
+* ``refundRequest.completed`` MUST be ``false``.
+* The ``rawTx`` MUST decode to a valid transaction that transfers the amount specified in the ``RefundRequest`` struct. It MUST be a transaction to the correct address, and provide the expected OP_RETURN, based on the ``RefundRequest``.
+* The ``merkleProof`` MUST contain a valid proof of of ``rawTX``.
+* The bitcoin payment MUST have been submitted to the relay chain, and MUST have sufficient confirmations.
+* The ``vault.status`` MUST be ``active``.
+* The ``vault.isBanned()`` MUST return ``false``.
+* The refunding vault MUST have enough collateral to mint an amount equal to the refund fee.
+
+*Postconditions*
+
+* The ``vault.issuedTokens`` MUST increase by ``fee``.
+* The ``TotalSupply`` in the :ref:`treasury-module` MUST increase by ``fee``.
+* The vault's ``SLA`` MUST increase by the :ref:`sla` score of ``Refund``.


### PR DESCRIPTION
In case 2.b of `executeRefund` (vault refunds but does not have collateral to back interbtc fee) - there is no SLA awarded for the action. Should we not change this?