### PR TITLE
fix: banned vaults can mint reimbursed tokens

### DIFF
--- a/docs/spec/redeem.rst
+++ b/docs/spec/redeem.rst
@@ -377,7 +377,6 @@ Specification
 * ``redeem.status`` MUST be ``Reimbursed(false)``.
 * The ``vault`` MUST equal ``redeemRequest.vault``.
 * The vault MUST have sufficient collateral to remain above the :ref:`SecureCollateralThreshold` after issuing ``redeem.amountBtc + redeem.transferFeeBtc`` tokens.
-* The vault MUST NOT be banned.
 * The function call MUST be signed by ``redeem.vault``, i.e. this function can only be called by the vault.
 
 *Postconditions*


### PR DESCRIPTION
Signed-off-by: Gregory Hill <gregorydhill@outlook.com>